### PR TITLE
Patch linkinator

### DIFF
--- a/.github/workflows/run-linkinator.yml
+++ b/.github/workflows/run-linkinator.yml
@@ -2,7 +2,6 @@ on:
   schedule:
     # Run everyday at 01:00 UTC
     - cron: '0 1 * * *'
-  push:
 name: linkinator
 jobs:
   linkinator:


### PR DESCRIPTION
Fixes centerofci/mathesar#155

Updates the linkinator action to use a patched version that also logs the parent url.  A PR to the original repo is open at https://github.com/JustinBeckwith/linkinator-action/pull/70, so hopefully we can revert this later. 