### PR TITLE
Fix automation error with back-to-back commits

### DIFF
--- a/.github/workflows/organize-images.yml
+++ b/.github/workflows/organize-images.yml
@@ -5,6 +5,10 @@ jobs:
   replace-external-links:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -38,6 +42,10 @@ jobs:
     needs: [replace-external-links]
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes centerofci/mathesar#309

Updates the github actions with [`Cancel Workflow Action`](https://github.com/marketplace/actions/cancel-workflow-action), which causes new commits to cancel old ones. As a result, any actions running on a commit which would cause a conflict should be cancelled. As a safety net, we also `git pull` before pushing, exiting if there are merge errors. 