### PR TITLE
Improve comms how-to

### DIFF
--- a/team/guide/comms-assignee.md
+++ b/team/guide/comms-assignee.md
@@ -10,7 +10,7 @@ dateCreated: 2021-10-23T18:49:14.482Z
 
 Every week, one person from the Mathesar [core team](/team) is assigned to be the "Comms Assignee". This means that they are in charge of communication with the community for that week.
 
-# Current Schedule
+## Current Schedule
 
 | Week | Person |
 |-|-|
@@ -21,22 +21,29 @@ Every week, one person from the Mathesar [core team](/team) is assigned to be th
 | Nov 29 to Dec 3 | Pavish |
 | Dec 6 to Dec 10 | Mukesh |
 
-# Responsibilities
+## Purpose
 
 The idea behind the Comms Assignee is to let the rest of the team ignore GitHub notifications if they need to and trust that the Comms Assignee will let them know if there's anything they need to do, such as weigh in on an issue or review a pull request.
 
-### New messages
-The Comms Assignee should aim to respond to all these forms of communication within one business day.
+## How to do comms
 
-- Community messages on [Matrix](/community).
-- New GitHub issues (see: [Issue Triage](/team/guide/issue-triage))
-- New GitHub issue comments (see: [Issue Assignment](/team/guide/issue-assignment))
-- New GitHub pull requests and pull request comments (see: [Code Review](/engineering/code-review))
+### Every day
 
-The Comms Assignee should pull in other team members as needed (e.g. if a pull request needs review or if there's a question and it is not the person's area of expertise).
+1. Respond to [Matrix](/community) messages from community members in all channels.
+1. Look through [newly created issues](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue) and [triage](/team/guide/issue-triage) them.
+1. Look through [recently updated issues](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-desc) and [assign](/team/guide/issue-assignment) issues to community members who comment with intent to start work.
+1. Look through [new PRs](https://github.com/centerofci/mathesar/pulls?q=is%3Aopen+is%3Apr) for any lacking an assigned [reviewer](/engineering/code-review). Comment on the PR, requesting a review by tagging specific team members who you think would be suited to review it.
 
-The one business day timeline is just for a response, we do not (for example) have to fully review a pull request within a day, we can comment on the PR, thank the contributor, and let them know when they can expect their PR to be reviewed.
+Ensure community members receive a response within 1 business day, either from you or someone else. You don't need to resolve everything within one day though. With a new PR for example, you can comment on it, thank the contributor, and let them know when they can expect their PR to be reviewed.
 
-### Open pull requests
+### Once per week 
 
-The Comms Assignee should check in on PRs from community contributors that have not seen any updates in a while. It might be nice to ask if the community contributor needs any help.
+- Open pull requests
+
+    The Comms Assignee should check in on PRs from community contributors that have not seen any updates in a while. Do your best to help move the PR towards completion which include asking if the contributor needs any help.
+
+## Notes
+
+- Delegate tasks to other team members in as needed.
+
+- Thank new contributors for their time and point them towards other ways to get help if they need it.

--- a/team/guide/issue-triage.md
+++ b/team/guide/issue-triage.md
@@ -41,7 +41,7 @@ Triaging an issue means setting all the appropriate fields on it.
 
 1. **Set milestone**
 
-    If an issue is directly associated with a feature, put it in the milestone for that feature. Otherwise, put it in a monthly improvement milestone (named like `YYYY-MD improvements`) according to priority. More urgent issues should go in this month's milestone, otherwise put it in a milestone in the next couple of months.
+    If an issue is directly associated with a feature, put it in the milestone for that feature. Otherwise, put it in a "General Improvements" milestone according to priority. More urgent issues should go in this month's milestone, otherwise put it in a milestone in the next couple of months.
 
     If you don't know what milestone to put something in, talk to Kriti.
 

--- a/team/guide/issue-triage.md
+++ b/team/guide/issue-triage.md
@@ -8,65 +8,41 @@ editor: markdown
 dateCreated: 2021-08-31T15:44:09.044Z
 ---
 
-> This page is aimed at members of [the Mathesar team](/team), since only they have the access to triage issues.
-{.is-info}
+Triaging an issue means setting all the appropriate fields on it.
 
-This guide describes how to properly triage new issues to work with Mathesar's development process.. It applies to both issues you're creating or issues that have been created by community members.
+## Responsibility
 
-## What does it mean for an issue to be triaged?
-All issues must:
-- Have a standard set of labels,
-- Have the appropriate fields set in our GitHub project.
-- Be in a milestone.
+- Everyone creating issues should do their best to triage them at creation time.
+- [Team](/team) members also [rotate](/team/guide/comms-assignee) responsibility for catching issues that were not triaged during creation.
 
-New issues are automatically created with the `status: triage` label and are automatically added to our GitHub project.
+## How to triage one issue
 
-## Who should triage issues?
-Any member of [the Mathesar core or community team](/team) is encouraged to triage issues. If you're making an issue, please ensure that it is triaged as well.
+1. **Set required labels**
 
-## How should I triage issues?
-Each step in the triage process is detailed below.
+    | Prefix | Required count | Notes |
+    | - | - | - |
+    | `work:` | 1+ | All `work: design` issues should also be marked `restricted: design team` because only the design team can currently work on those. |
+    | `type:` | 1 | |
+    | `status:` | 1 | _Should not be `status: triage`_ |
 
-### Applying labels
-All issues should have the following labels:
-- One or more `work:` labels. These describe the kind of work involved in the issue (frontend, backend, documentation, design, etc.)
-- One `type:` label. This describes the kind of problem that the issue is solving (bug, enhancement, etc.) This may be automatically present based on the issue template.
-  - There's also a `question` label for issues that are questions and not problems.
-  - `type: meta` issues collect other issues and are not meant to be worked on directly.
-- One `status:` label describing the current status of the issue. If the issue has been triaged, this should not be `status: triage`.
+1. **Set optional labels**
+  
+    Scan through the full labels list and apply other labels as necessary. Learn more about the [meaning of all our labels](https://github.com/centerofci/mathesar/labels).
 
-There are also other labels you should consider applying:
-- `priority` labels for issues that are either urgent or are for future consideration.
-- `restricted:` labels for issues that are not open to the community.
-  - All `work: design` issues should also be marked `restricted: design team` because only the design team can currently work on those.
-  - Consider marking complicated issues or issues that touch the fundamental architecture of Mathesar as `restricted: maintainers`.
-- `good first issue` and `help wanted` labels for issues that are particularly suitable for community contribution.
-  - Ensure that `help wanted` is applied to all issues of this type, but only apply `good first issue` in addition to `help wanted` if the issue is approachable for new and inexperienced contributors.
-- `affects:` labels for issues that touch technical debt, architecture, DX, or UX.
-- Any other labels that apply from our [repository's configured labels](https://github.com/centerofci/mathesar/labels).
 
-Applying the correct label should also sort the issue correctly in the Mathesar GitHub project.
+1. **Verify Project and fields**
 
-### Ensure the issue is sorted correctly in the Mathesar project
+    Set the Project to "Mathesar".
 
-The [Mathesar GitHub project](https://github.com/orgs/centerofci/projects/1) organizes our open issues. We need to ensure that the issue is in the project and the following fields are set correctly.
-- Status
-- Priority
-- Work
+    Within the project, ensure that the `status`, `priority`, and `work` fields are set.
 
-This process should be fully automated based on setting the correct labels in the previous step.
+    > The project is only accessible to [Team](/team) members, but all relevant information (such as status, priority, and milestone) should be available on individual issues. We will make this project public as soon as GitHub supports it.
+    {.is-warning}
 
-> The project is only accessible to [Team](/team) members, but all relevant information (such as status, priority, and milestone) should be available on individual issues. We will make this project public as soon as GitHub supports it.
-{.is-warning}
+1. **Set milestone**
 
-### Assigning milestones
-All issues should have a milestone.
+    If an issue is directly associated with a feature, put it in the milestone for that feature. Otherwise, put it in a monthly improvement milestone (named like `YYYY-MD improvements`) according to priority. More urgent issues should go in this month's milestone, otherwise put it in a milestone in the next couple of months.
 
-If an issue is directly associated with a feature, put it in the milestone for that feature. Otherwise, put it in a monthly improvement milestone (named like `YYYY-MD improvements`) according to priority. More urgent issues should go in this month's milestone, otherwise put it in a milestone in the next couple of months.
+    If you don't know what milestone to put something in, talk to Kriti.
 
-If you don't know what milestone to put something in, talk to Kriti.
-
-**Do not create any new milestones.**
-
-## I have a question
-Talk to Kriti.
+    Do not create any new milestones.


### PR DESCRIPTION
Here's a bit of clean up to the comms documentation

- Cut content that's obvious. 
- Better highlight points that are not obvious.
- Use clearer imperative language to improve readability.

@kgodey 