### PR TITLE
Add Mathesar description to GSoC applicant entry point.

### DIFF
--- a/community/mentoring.md
+++ b/community/mentoring.md
@@ -8,10 +8,7 @@ editor: markdown
 dateCreated: 2022-01-18T19:23:06.554Z
 ---
 
-The Mathesar team is applying to be a mentoring organization for **Google Summer of Code 2022**. We are hoping to work with GSoC interns to create an intuitive user interface to relational databases.
-
-In the future, we may participate in other programs such as Outreachy, CommunityBridge, etc.
-
+The Mathesar team is applying to be a mentoring organization for **Google Summer of Code 2022**. We are hoping to work with GSoC mentees to help us create an intuitive user interface for non-technical users to work with relational databases.
 
 ## For Applicants
 - [Project Ideas *Current list of project ideas for our mentorship programs.*](/community/mentoring/project-ideas)

--- a/community/mentoring.md
+++ b/community/mentoring.md
@@ -8,9 +8,10 @@ editor: markdown
 dateCreated: 2022-01-18T19:23:06.554Z
 ---
 
-The Mathesar team is applying to be a mentoring organization for **Google Summer of Code 2022**.
+The Mathesar team is applying to be a mentoring organization for **Google Summer of Code 2022**. We are hoping to work with GSoC interns to create an intuitive user interface to relational databases.
 
 In the future, we may participate in other programs such as Outreachy, CommunityBridge, etc.
+
 
 ## For Applicants
 - [Project Ideas *Current list of project ideas for our mentorship programs.*](/community/mentoring/project-ideas)


### PR DESCRIPTION
This PR adds a _very short_ description of Mathesar to the wiki entry point for GSoC applicants.  My reasoning is that we should (re)hook them when they first come to the wiki so they are more willing to invest some time exploring further.