### PR TITLE
docs: update import-preview-api spec

### DIFF
--- a/engineering/specs/import-preview-api.md
+++ b/engineering/specs/import-preview-api.md
@@ -29,22 +29,31 @@ The `columns` endpoint will now include the possible targets for type alteration
 
 For previewing the inferred types and names of columns, we will use a new `previews` endpoint under the table detail endpoint.  We'll submit a `POST` to the endpoint to create the preview, and then receive a JSON formatted as in the normal table detail endpoint in return with the modified table.
 ```
-POST /api/vX/tables/<table_id>/previews/
+POST /api/db/vX/tables/<table_id>/previews/
 ```
 could have submitted JSON like:
 ```json
 {
     "columns": [
-        {},
         {
-            "name": "Center2",
+            "name": "mathesar_id",
+            "type": "INTEGER",
         },
         {
-            "type": "string"
+            "name": "Center2",
+            "type": "VARCHAR"
+        },
+        {
+            "name": "Status",
+            "type": "VARCHAR"
         },
         {
             "name": "Case Number",
-            "type": "string"
+            "type": "VARCHAR"
+        },
+        {
+            "name": "Patent Number",
+            "type": "TEXT"
         }
     ]
 }
@@ -59,20 +68,39 @@ The full table blob should be returned, so a return for the above request could 
     "updated_at": "2021-07-07T09:00:30.108707Z",
     "columns": [
         {
+            "id": 1,
             "name": "mathesar_id",
-            "type": "INTEGER"
+            "type": "INTEGER",
+            "type_options": null,
+            "display_options": null
         },
         {
+            "id": 2,
             "name": "Center2",
-            "type": "VARCHAR"
+            "type": "VARCHAR",
+            "type_options": null,
+            "display_options": null
         },
         {
+            "id": 3,
             "name": "Status",
-            "type": "VARCHAR"
+            "type": "VARCHAR",
+            "type_options": null,
+            "display_options": null
         },
         {
+            "id": 4,
             "name": "Case Number",
-            "type": "VARCHAR"
+            "type": "VARCHAR",
+            "type_options": null,
+            "display_options": null
+        },
+        {
+            "id": 5,
+            "name": "Patent Number",
+            "type": "TEXT",
+            "type_options": null,
+            "display_options": null
         }
     ],
     "records": "http://localhost:8000/api/v0/tables/1/records/",
@@ -83,12 +111,6 @@ The full table blob should be returned, so a return for the above request could 
 ```
 
 
-This would set the columns in the preview to have the specified names and types.  Any column which is unaltered would have and empty JSON object (as in the 0th column above), otherwise, only attributes of a column which are to be altered would be submitted in the request.  So, in the example:
-- we alter nothing about the 0th column,
-- we alter the name of the 1st column, 
-- we alter the type of the 2nd column, and
-- we alter both the name and type of the 3rd column.
-
 ### Implementation of Preview
 
 Because we eventually want to do type inference in a temporary table, we'll avoid using the table resulting from the current process in the preview action.  Instead, the implementation will simply put together a select with casts (using the custom casting functions defined by the Mathesar installation) and aliases.
@@ -98,5 +120,85 @@ Because we eventually want to do type inference in a temporary table, we'll avoi
 The changes to column types and names can be saved by submitting a `PATCH` request to the `tables` endpoint, with the column list being the same as the `previews` request.  
 
 Table name changes should be submitted using the already existing `PATCH` behavior (i.e., a `PATCH` with the `name` key changed).
+
+```
+PATCH /api/db/db/vX/tables/<table_id>
+```
+could submit a JSON like:
+```json
+{
+    "columns": [
+        {},
+        {
+            "id": 2,
+            "name": "Center"
+        },
+        {
+            "id": 3,
+            "type": "TEXT"
+        },
+        {
+            "id": 4,
+        },
+        {
+            "id": 5,
+            "name": "Patent ID",
+            "type": "INTEGER"
+        }
+    ]
+}
+```
+The full table blob will be returned, so a return for the above request could be something like:
+```json
+{
+    "id": 1,
+    "name": "the_patents_table",
+    "schema": 2,
+    "created_at": "2021-07-07T09:00:30.108653Z",
+    "updated_at": "2021-07-07T09:00:30.108707Z",
+    "columns": [
+        {
+            "id": 1,
+            "name": "mathesar_id",
+            "type": "INTEGER",
+            "type_options": null,
+            "display_options": null
+        },
+        {
+            "id": 2,
+            "name": "Center",
+            "type": "VARCHAR",
+            "type_options": null,
+            "display_options": null
+        },
+        {
+            "id": 3,
+            "name": "Status",
+            "type": "TEXT",
+            "type_options": null,
+            "display_options": null
+        },
+        {
+            "id": 5,
+            "name": "Patent ID",
+            "type": "INTEGER",
+            "type_options": null,
+            "display_options": null
+        }
+    ],
+    "records": "http://localhost:8000/api/v0/tables/1/records/",
+    "data_files": [
+        1
+    ]
+}
+```
+
+
+This would set the columns in the preview to have the specified names and types. Any column which is unaltered would have and empty JSON object (as in the 0th column above), otherwise, only attributes of a column which are to be altered would be submitted in the request. So, in the example:
+- we alter nothing about the 0th column,
+- we alter the name of the 1st column, 
+- we alter the type of the 2nd column,
+- we dropped the 3rd column, and
+- we alter both the name and type of the 4th column.
 
 Please note that both name and columns cannot be changed in the same request at the moment.

--- a/engineering/specs/import-preview-api.md
+++ b/engineering/specs/import-preview-api.md
@@ -122,7 +122,7 @@ The changes to column types and names can be saved by submitting a `PATCH` reque
 Table name changes should be submitted using the already existing `PATCH` behavior (i.e., a `PATCH` with the `name` key changed).
 
 ```
-PATCH /api/db/db/vX/tables/<table_id>
+PATCH /api/db/vX/tables/<table_id>
 ```
 could submit a JSON like:
 ```json


### PR DESCRIPTION
As suggested in issue [#1167](https://github.com/centerofci/mathesar/issues/1167) we will be using id to reference the columns for the purpose of patching them. Now that the above will be implemented by the PR [#1307](https://github.com/centerofci/mathesar/pull/1307), this PR updates the import preview api spec with the new changes in the api request schema.