### PR TITLE
Rework "contributing" page for clarity and changes to community contributor workflow

### DIFF
--- a/community/contributing.md
+++ b/community/contributing.md
@@ -8,42 +8,62 @@ editor: markdown
 dateCreated: 2021-06-03T13:18:27.111Z
 ---
 
-We welcome contributions of all kinds to Mathesar!
+Mathesar's development happens on [GitHub](https://github.com/centerofci/mathesar). We welcome contributions of all kind!
 
-If you have any questions, please don't hesitate to ask. See the [Community](/community) page for how to find us.
+## Contributing code
 
-# Code
-Mathesar's development happens on [GitHub](https://github.com/centerofci/mathesar). If you are not familiar with GitHub or pull requests, please follow [GitHub's "Hello World" guide](https://guides.github.com/activities/hello-world/) first.
+1. Get Mathesar [running locally](https://github.com/centerofci/mathesar/blob/master/README.md#local-development).
 
-You may also want to visit our [Engineering](/engineering) page to learn more about our development process.
+    Make sure to **do this before moving on**. If you need help, ask in [Matrix](/community/matrix.md), taking care to form _specific_ questions that people can answer asynchronously.
 
-## Finding an Issue
-You can find an issue to work on from our [issues page](https://github.com/centerofci/mathesar/issues).
-  - Unassigned issues tagged `good first issue` or `help wanted` are especially tagged for contributors.
-    - [Issues tagged `good first issue`](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22good+first+issue%22)
-    - [Issues tagged `help wanted`](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22help+wanted%22)
-  - Unassigned issues tagged `status: ready` are also fair game.
-    - [Issues tagged `status: ready`](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+ready%22+no%3Aassignee).
+1. Find an [issue](https://github.com/centerofci/mathesar/issues) to work on.
 
-If you want to work on something for which there is no GitHub issue open yet, create an issue and propose your change there. A Mathesar [team member](/team) will evaluate your issue and decide whether we'll accept a pull request for the issue. If we indicate that we will accept a PR, then go ahead and start work on it.
+    - ✅ Our easiest issues are labeled [good first issue](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22good+first+issue%22) and are a great place to start. However keep in mind that we're not always entirely sure of the necessary steps to solve a problem when we open an issue. 
+    - ✅ Slightly more challenging issues are still labeled [help wanted](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22help+wanted%22). These can be a good place to start if you have some experience coding but are not yet familiar with our codebase.
+    - ❌ Issues are not appropriate if they meet any of the following criteria:
+        - already assigned to someone
+        - labeled with a `restricted: ...` label
+        - labeled with any `status: ...` label other than `status: ready`
+    - ⚠️ Some issues fall into a middle ground, not being labeled "help wanted" or "restricted". These tickets are more challenging and are only appropriate for community contributors who are familiar with our codebase.
 
-## Joining the Community
-It would be helpful for you to join the "Mathesar - General" channel on our [Matrix server](/community/matrix) and introduce yourself. You can ask any questions about the project or finding issues here as well.
+    If you want to work on something for which there is no GitHub issue open yet, create an issue and propose your change there. A Mathesar [team member](/team.md) will evaluate your issue and decide whether we'll accept a pull request for the issue.
 
-You may also want to join the [`mathesar-developers` mailing list](/community/mailing-lists). The team uses it to discuss new features and send updates to everyone working on the project.
+1. Claim the issue.
 
-## Contributing
-Once you've found an issue to work on, 
+    1. Comment on the ticket, saying _"I'd like to work on this"_ or similar.
+    1. A core team member will assign you to the ticket.
+    1. At this point **you have one week to follow up.** If we don't hear from you by then, we will unassign you from the ticket so that others may claim it. If you need more time, you can ask for an extension, explaining the progress you've made and the challenges you've encountered. If you have not begun work at all, then we will need to unassign you.
 
-- Comment on it and say you'd like to work on that issue. This is so we can keep track of who is interested in each issue.
-- Write your code and submit your pull request. Be sure to read and follow our [code review guidelines](/engineering/code-review).
-- Wait for code review and address any issues raised as soon as you can.
+    Please do not claim more than 2 issues concurrently before submitting PRs.
 
-## Code Review
-We encourage and appreciate code review by contributors. Feel free to review any open pull requests. Follow our [code review guidelines](/engineering/code-review).
+1. Begin making your changes
 
-# Design
+    - Make sure to follow our [code standards](/engineering/standards.md).
+
+    - If you are not familiar with GitHub or pull requests, please follow [GitHub's "Hello World" guide](https://guides.github.com/activities/hello-world/) first. Make sure to commit your changes on a new git branch named after the ticket you claimed (instead of on `master`).
+
+    - Commit early, commit often. Write good commit messages. Try to keep pull requests small if possible, since it makes review easier.
+
+    - If you expect your work to last longer than 1 week, open a draft pull request for your in-progress work.
+
+1. Open a PR
+
+    When you are ready for a core team member to review your changes, open a pull request (or mark your draft PR as ready for review). If you have already been corresponding with a core team member about the issue, then you may request a review from that person. Otherwise, you may leave your PR without any review requests and a core team member will assign someone to review it.
+
+1. Wait for code review and address any issues raised as soon as you can.
+
+    - When making changes to address review critique, feel free to reply to threads within the PR (especially to point to specific commits which you think should address the critique), but do not click the "Resolve conversation" button on threads which other people have started.
+    - If you are ready for a subsequent round of review, comment on the PR requesting another review and tagging the original reviewer.
+
+## Contributing PR reviews
+
+We encourage and appreciate code review by contributors. Feel free to review any open pull requests. Follow our [code review guidelines](/engineering/code-review.md).
+
+
+## Contributing to UX and graphic design
+
 > Due to limited capacity, we are currently unable to accept design volunteers. Please return to this page for updates.
 {.is-warning}
 
-Please read through our [Design](/design) section to learn more about our design process.
+Please read through our [Design](/design.md) section to learn more about our design process.
+

--- a/community/contributing.md
+++ b/community/contributing.md
@@ -12,11 +12,11 @@ Mathesar's development happens on [GitHub](https://github.com/centerofci/mathesa
 
 ## Contributing code
 
-1. Get Mathesar [running locally](https://github.com/centerofci/mathesar/blob/master/README.md#local-development).
+1. **Get Mathesar [running locally](https://github.com/centerofci/mathesar/blob/master/README.md#local-development).**
 
-    Make sure to **do this before moving on**. If you need help, ask in [Matrix](/community/matrix.md), taking care to form _specific_ questions that people can answer asynchronously.
+    Make sure to **do this before moving on**. If you need help, ask in [Matrix](/community/matrix.md), taking care to form *specific* questions that people can answer asynchronously.
 
-1. Find an [issue](https://github.com/centerofci/mathesar/issues) to work on.
+1. **Find an [issue](https://github.com/centerofci/mathesar/issues) to work on.**
 
     - ✅ Our easiest issues are labeled [good first issue](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22good+first+issue%22) and are a great place to start. However keep in mind that we're not always entirely sure of the necessary steps to solve a problem when we open an issue. 
     - ✅ Slightly more challenging issues are still labeled [help wanted](https://github.com/centerofci/mathesar/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22help+wanted%22). These can be a good place to start if you have some experience coding but are not yet familiar with our codebase.
@@ -28,29 +28,32 @@ Mathesar's development happens on [GitHub](https://github.com/centerofci/mathesa
 
     If you want to work on something for which there is no GitHub issue open yet, create an issue and propose your change there. A Mathesar [team member](/team.md) will evaluate your issue and decide whether we'll accept a pull request for the issue.
 
-1. Claim the issue.
+1. ***(Optionally)* Claim the issue.**
 
-    1. Comment on the ticket, saying _"I'd like to work on this"_ or similar.
+    If the Mathesar team has already merged one of your PRs, then you may wish to ear-mark the issue for yourself so that other do not work on it concurrently.
+    
+    However, **if you are band new to Mathesar, we recommend skipping this step** and making your changes *without* claiming the issue. (A core team member will assign the issue to you *after* you open a PR.) This recommendation is designed to reduce the overhead the core team has experienced from a high volume of contributors failing to follow through with their intent to submit PRs.
+
+    If you decide to claim the issue:
+
+    1. Comment on the ticket, saying *"I'd like to work on this"* or similar.
     1. A core team member will assign you to the ticket.
     1. At this point **you have one week to follow up.** If we don't hear from you by then, we will unassign you from the ticket so that others may claim it. If you need more time, you can ask for an extension, explaining the progress you've made and the challenges you've encountered. If you have not begun work at all, then we will need to unassign you.
 
     Please do not claim more than 2 issues concurrently before submitting PRs.
 
-1. Begin making your changes
+1. **Begin making your changes.**
 
     - Make sure to follow our [code standards](/engineering/standards.md).
-
     - If you are not familiar with GitHub or pull requests, please follow [GitHub's "Hello World" guide](https://guides.github.com/activities/hello-world/) first. Make sure to commit your changes on a new git branch named after the ticket you claimed (instead of on `master`).
-
     - Commit early, commit often. Write good commit messages. Try to keep pull requests small if possible, since it makes review easier.
-
     - If you expect your work to last longer than 1 week, open a draft pull request for your in-progress work.
 
-1. Open a PR
+1. **Open a PR.**
 
     When you are ready for a core team member to review your changes, open a pull request (or mark your draft PR as ready for review). If you have already been corresponding with a core team member about the issue, then you may request a review from that person. Otherwise, you may leave your PR without any review requests and a core team member will assign someone to review it.
 
-1. Wait for code review and address any issues raised as soon as you can.
+1. **Address critique from PR review.**
 
     - When making changes to address review critique, feel free to reply to threads within the PR (especially to point to specific commits which you think should address the critique), but do not click the "Resolve conversation" button on threads which other people have started.
     - If you are ready for a subsequent round of review, comment on the PR requesting another review and tagging the original reviewer.

--- a/engineering/code-review.md
+++ b/engineering/code-review.md
@@ -8,58 +8,27 @@ editor: markdown
 dateCreated: 2021-04-29T17:28:01.167Z
 ---
 
-
-
-Please follow these guidelines when reviewing PRs.
-
-# Authors
-- If your code is ready to be reviewed and merged:
-  - Once you think your code is ready to merge, mark your draft pull request as "ready for review" or create a pull request if you don't have a draft. The required reviewers will automatically be notified when you do this.
-
-- Else, if your code is ready to be reviewed, but not ready to be merged (for example, when it depends on another PR):
-  - Submit the pull request as draft.
-  - Leave it as draft.
-  - Add label `status:review`.
-  - Assign reviewers manually.
-- You can post on the [`#code-review:matrix.mathesar.org`](https://matrix.to/#/#code-review:matrix.mathesar.org) for urgent PRs or to ask for optional review of draft PRs.
-- If the reviewer requests changes, please make the changes and **re-request review**.
-- Do not mark comments as resolved in the GitHub UI, let the reviewer do this.
-- If the reviewer has approved the PR but not merged it, feel free to merge the PR yourself.
-- Please avoid breaking changes to the API.  If they absolutely can't be avoided, please follow the process described [here](/team/guide/workflow#in-case-of-breaking-api-changes).
-
-## General Advice
-- Commit early, commit often.
-- Write good commit messages.
-- Create draft pull requests for in-progress work.
-- Try to keep pull requests small if possible, since it makes review easier.
-
-# Reviewers
 Anyone is welcome to review pull requests!
 
-- Request changes if you want another look at the PR before it is merged.
-- Resolve your own comments, do not resolve anyone else's.
-- If the branch needs to be updated before merging (because it's out-of-date with the `master` branch), do so, as long as the merge can be performed automatically.  Otherwise, ask the Author to handle it.
-- See [Backend Code Review](/engineering/code-review/backend) for guidelines specific to backend code.
-
-## Maintainers
 If your review is requested, it means that you are responsible for reviewing the pull request. If the PR is large or you think someone who is familiar with a specific part of the code would be helpful, feel free to request additional reviewers through the GitHub interface.
 
-### Process
-- Check for outstanding PRs at least **once a day**.
+## Process
 - We should be aiming to turn around PR reviews within 1-2 working days. This means that there should be movement on the PR every 1-2 days, a new review, code review fixes, repeat if needed, and then merge.
 - If you approve the PR, merge it unless someone else has requested changes.
   - If the person who has requested changes is unavailable, merge the PR anyway.
 - Always merge using merge commits, never squash or rebase (the GitHub interface should disable squash and rebase, but check just in case).
 - If the PR is from a community contributor and it only requires minor changes, feel free to make the changes yourself and merge them.
 
-### Tips
+## Tips
+- If the branch needs to be updated before merging (because it's out-of-date with the `master` branch), do so, as long as the merge can be performed automatically.  Otherwise, ask the Author to handle it.
+- See [Backend Code Review](/engineering/code-review/backend) for guidelines specific to backend code.
 - We should be aiming to merge PRs in and create new issues for improvements rather than keeping PRs in review until every possible issue is fixed.
 - Code review should be a fairly quick process. Reviewers should be focused on asking the right questions, not on doing research into the answers and suggesting them. 
     - e.g. if you're wondering if the author considered a particular implication of a change they made, ask them that instead of doing research into all the implications yourself and informing the author of them.
 - If you'd like to reconsider the architecture of a PR, create a draft issue for figuring that out rather than blocking the PR until you figure out the right architecture.
 - When reviewing community contributed PRs, if it's easier to make the changes yourself rather than describe the changes needed as a code review, just make the changes and merge the PR. You can explain what you did and thank the contributor for their work.
 
-### Modifying PRs before merging
+## Modifying PRs before merging
 You can modify an in progress PR before merging, if necessary.  If the PR is from a branch in the official Mathesar repository, just modify that branch.  If it's in a branch of a fork, it's a bit more complicated.  The smoothest way in that case is to
 1. Add the fork repo as a remote, locked to the appropriate branch and fetch:
    ```shell
@@ -76,15 +45,15 @@ You can modify an in progress PR before merging, if necessary.  If the PR is fro
 
 If (3) fails, it may be a permissions issue.  In that case, you'll have to make a new branch in the official Mathesar repo based off of the PR.  To do that, follow the instructions [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).
 
-# Reading
+## Reading
 Some reading related to our process:
 
-## Why not squash or rebase merges?
+### Why not squash or rebase merges?
 - [Why I’m against merging pull requests in squash mode or rebase mode?](https://myst729.github.io/posts/2019/on-merging-pull-requests/)
 - [Squash merges are evil](https://medium.com/bananatag-engineering-blog/squash-merges-are-evil-171f55139c51)
 - [Why git squash merges are bad](https://felixmoessbauer.com/blog-reader/why-git-squash-merges-are-bad.html)
 - [Git merge - to squash or not to squash? - Stack Overflow](https://stackoverflow.com/questions/26999930/git-merge-to-squash-or-not-to-squash)
 
-## Commits
+### Commits
 - [Commit early, push often](https://www.worklytics.co/commit-early-push-often/)
 - [Commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)


### PR DESCRIPTION
## Summary

This PR alters our Contributor Guide as follows:

- Modify our workflow for community contributors as follows:
    - **Assign tickets to community contributors**
    - Give community contributors **1 week** to follow up after claiming a ticket
    - Stipulate that community contributors are to **claim no more than 2 tickets at a time**
- Move content from `code-review.md` to `contributing.md` which is intended for _authors_ to read. This change narrows the intended audience of `code-review.md` to be only _code reviewers_.
- Tighten language across `contributing.md`, making it clearer and more imperative.

## Context and motivation

As I've been opening a lot of "help wanted" tickets lately and fielding incoming comments from new contributors, I've been seeing some problems with our current workflow that I'd like to improve.


## Some challenges that inevitably arise with community contributors

- (A) contributor calls dibs on too many tickets in parallel
- (B) contributor commits to working on a ticket but fails to follow through
- (C) contributor jumps on someone else's ticket, either via requesting dibs or via opening a PR
- (D) contributor wants to work on a ticket which someone has already abandoned but does not because they're not sure it's abandoned


## Our current process

- We don't assign tickets to community contributors
- When a community contributor expresses interest in working on a ticket, a core team member replies to their comment with something like "sure, go ahead".


## Problems I'm experiencing with our current process

- The Contributor Guide lacks clarity on our approach to handling the above challenges. For example, how many ticket do we deem _appropriate_ for one person to claim before submitting a PR for any? How long does someone have to submit a PR after calling dibs? Our lack of clarity leaves new contributors to form their own assumptions about our approach, and it also leaves core team members unsure of how to respond to some of those situations.

- When a new contributor comments on a ticket with something like,

    > I'd like to work on this, may I please be assigned?

    ...I find it tricky to craft a response. _"Yes, you can work on it... But, no, we're not going to assign you to it."_ I imagine that might be confusing to some people. I've found myself attempting to explain _why_ we don't assign tickets, and it's a bit cumbersome.

- Addressing challenge (A) is difficult without assigning tickets. Sometimes I hesitate before confirming that a new contributor may work on a ticket. _"Hmmm, I think I've seen this person before"_, I might think. But I don't have a good way of asking GitHub how many tickets that person is already working on. With a workflow that utilizes assignments, I can easily answer that question.

- Addressing challenges (C) and (D) become more murky and subjective. If the ticket is unassigned but has a "dibs" comment 1 week ago, can a new contributor work on it?

## Problems with assigning tickets (and my plan to address them)

- We moved away from assigning tickets mostly due to challenge (B). We didn't want to manage the overhead of un-assigning people from tickets.

    Well, I'm here to say: **I want to manage the overhead of unassigning people from tickets.** I'd like to roll this into my triage work. If it's not easy, I'll find a way to make it easy. I've been using [gh](https://github.com/cli/cli) for my triage work and it's been great. I'll try something similar for this new task where I look for tickets that were assigned to community contributors over 1 week ago without any PR or comment. It'll take a little massaging to get right, I'd rather take on that mess than the mess I currently have responding to new contributors with our current workflow.

