### PR TITLE
Add meta-docs page proposing a modified strategy for organizing our documentation

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -15,9 +15,9 @@ This page describes our various documentation sources and seeks to eliminate gra
 - Source: https://github.com/centerofci/mathesar/tree/master/docs
 - Published: https://docs.mathesar.org/
 - Scope:
-    - **User docs** (we don't have this yet, but we wil eventually)
+    - **User docs**
     - **Administrator docs** (for people installing/upgrading Mathesar)
-- How do edit:
+- How to edit:
     1. Follow instructions within README to preview docs content locally using mkdocs.
     1. Base your edits on the correct branch:
         - Target `master` if you have an important fix which needs to be published for the currently-released version of Mathesar.
@@ -37,7 +37,7 @@ This page describes our various documentation sources and seeks to eliminate gra
     - **Architectural overviews**
     - **Module documentation**
     - (basically, anything about the *code itself*)
-- How do edit:
+- How to edit:
     1. Make a PR against the `develop` branch.
 - Tips:
     - Put documentation close to the code that it documents.
@@ -54,7 +54,7 @@ This page describes our various documentation sources and seeks to eliminate gra
     - **Roles and responsibilities**
     - **Specs**
     - **Meeting notes**
-- How do edit (choose any):
+- How to edit (choose any):
     - Make a PR to the repo if your edits warrant review/approval
     - Edit locally and push to `master` for smaller changes (there is no way to preview locally)
     - Edit through the wiki's web interface by logging in

--- a/documentation.md
+++ b/documentation.md
@@ -63,7 +63,7 @@ This page describes our various documentation sources and seeks to eliminate gra
 
 - Source:
     - https://hackmd.io/team/mathesar
-    - https://drive.google.com/
+    - https://drive.google.com/drive/u/0/folders/0AJzWWmnmukGHUk9PVA
     - https://github.com/centerofci/mathesar-private-notes
 - Scope:
     - ***Private* team docs**

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,70 @@
+---
+title: Documentation Strategy
+description: 
+published: true
+date: 2023-04-10T00:00:00.000Z
+tags: 
+editor: markdown
+dateCreated: 2023-04-10T00:00:00.000Z
+---
+
+This page describes our various documentation sources and seeks to eliminate gray area between them.
+
+## Docs site
+
+- Source: https://github.com/centerofci/mathesar/tree/master/docs
+- Published: https://docs.mathesar.org/
+- Scope:
+    - **User docs** (we don't have this yet, but we wil eventually)
+    - **Administrator docs** (for people installing/upgrading Mathesar)
+- How do edit:
+    1. Follow instructions within README to preview docs content locally using mkdocs.
+    1. Base your edits on the correct branch:
+        - Target `master` if you have an important fix which needs to be published for the currently-released version of Mathesar.
+        - Target `develop` if you are adding/updating documentation along with yet-to-be-released changes to the product.
+    1. Make a PR against the repo with your changes.
+- Notes:
+    - The docs site is published from the `master` branch. This is important because we want to ensure that it reflects the latest *released* version of Mathesar so that docs readers who are installing or using Mathesar don't see content before it's actually applicable.
+
+## Markdown near code
+
+- Source: Bespoke `.md` files scattered within https://github.com/centerofci/mathesar/
+- Published: *(nowhere, other than the GitHub web interface)*
+- Scope:
+    - **Developer docs**
+    - **Contributor guidelines**
+    - **Code standards**
+    - **Architectural overviews**
+    - **Module documentation**
+    - (basically, anything about the *code itself*)
+- How do edit:
+    1. Make a PR against the `develop` branch.
+- Tips:
+    - Put documentation close to the code that it documents.
+    - Use relative hyperlinks like `[Foo](./bar/foo.md)` to cross-reference other markdown files.
+    - Ensure that content is discoverable by linking to it from other places that readers are likely to look.
+
+## Wiki
+
+- Source: https://github.com/centerofci/mathesar-wiki
+- Published: https://wiki.mathesar.org
+- Scope:
+    - ***Public* team docs**
+    - **Project planning**
+    - **Roles and responsibilities**
+    - **Specs**
+    - **Meeting notes**
+- How do edit (choose any):
+    - Make a PR to the repo if your edits warrant review/approval
+    - Edit locally and push to `master` for smaller changes (there is no way to preview locally)
+    - Edit through the wiki's web interface by logging in
+
+## Other
+
+- Source:
+    - https://hackmd.io/team/mathesar
+    - https://drive.google.com/
+    - https://github.com/centerofci/mathesar-private-notes
+- Scope:
+    - ***Private* team docs**
+

--- a/home.md
+++ b/home.md
@@ -33,6 +33,7 @@ The Mathesar wiki is aimed at **people who are helping build Mathesar**. Please 
 - [:bulb: Product *Documentation about the high level ideas behind Mathesar*](./product.md)
 - [:art: Design *Documentation about Mathesar's visual design and UI*](./design.md)
 - [:desktop_computer: Engineering *Documentation about Mathesar's code*](./engineering.md)
+- [:book: Documentation Strategy *Meta-docs about our documentation*](./documentation.md)
 - [:loudspeaker: Marketing *Material for promoting Mathesar*](./marketing.md)
 - [:memo: Meeting Notes *Mathesar team meeting notes*](./meeting-notes.md)
 {.links-list}


### PR DESCRIPTION
## Before

- We have no codified guidelines on what documentation content should go in what places.
- We have a problem of edits to the dev docs not getting published
- Kriti and Sean [discussed this](https://wiki.mathesar.org/en/meeting-notes/2023-03/2023-03-29-team-meeting.md#where-to-put-what-kind-of-docs) at a meeting

## After

- The new guidelines stipulate that dev docs go in bespoke markdown files in the repo -- not in the wiki, not in the docs site.
- If we adopt these guidelines, I'll take responsibility for reorganizing the docs content to be in conformance with this new strategy. I'll make sure to provide lots of hyperlinks so that everything is discoverable.

